### PR TITLE
feat/multiple interpreter linking support

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -15,7 +15,7 @@ const createContext = ({ events, userContext, stepper }) => {
         __initialize__: contextSetup,
         Promise,
         step: async (...args) => stepper.step(...args),
-        ...withHandlerCounter(events, activeHandlers),
+        events: withHandlerCounter(events, activeHandlers),
         _execution: {
             stop: () => {
                 stepper.destroy();

--- a/test/interpreter.test.js
+++ b/test/interpreter.test.js
@@ -47,8 +47,8 @@ describe('interpreter', function () {
 
         it('onExecutionEndPromise should only be fulfilled when there are no more active event handlers', async function () {
             const code = `
-            const dispose = on('hanging', () => {});
-            once('dispose', dispose);
+            const dispose = events.on('hanging', () => {});
+            events.once('dispose', dispose);
           `;
 
             const execution = run(code);
@@ -231,7 +231,7 @@ describe('interpreter', function () {
             const eventHandler = sinon.fake();
             const emptyStack = sinon.fake();
             const code = `
-                once('test', eventHandler);
+                events.once('test', eventHandler);
                 emptyStack();
             `;
 
@@ -319,7 +319,7 @@ describe('interpreter', function () {
         });
         it('should be able to emit events from outside', async function () {
             const callback = sinon.fake();
-            const code = `once('test', callback)`;
+            const code = `events.once('test', callback)`;
 
             const execution = run(code, { context: { callback } });
             await execution;
@@ -334,7 +334,7 @@ describe('interpreter', function () {
 		    callback(arg); 
 	    	}
 
-		once('test', arg => {
+		events.once('test', arg => {
                     resolve(arg)}
                 )
 	`;


### PR DESCRIPTION
This MR contains the necessary changes for `step-interpreter` to support event piping through concurrently executing instances of itself.

Currently a code base consuming this library has no way to fully override the method(s) responsible for emitting events due to a timing issue.

After the `run` method is called, the internal VM of a given interpreter has already copied a reference to the emit method. The VM will then expose this (and any other methods fed to it) through it's own internal execution context, meaning that if at a later time that method was overriden, the user would simply be changing the method's reference in the step-interpreter instance while having no effect on the reference exposed through the VM's internal execution context. This is due to the fact that the VM's internal execution context is populated (from a user's perspective) during the call to it's constructor.

Since after the VM's intance has been created `step-interpreter` has no way to allow it's users to change values inside of the VM's internal execution context, we have the need to expose to the user a mutable object which should both be present in the VM's internal execution context and accessible through step-interpreter at the same time.

For this feature in particular, the object that will bridge the VM's execution context to the user's code base is a wrapper on an event emitter. Previously we would spread this object into the VM's internal execution context resulting in us injecting these "event emitter" methods individually, leading to the problem we described beforehand.
By not spreading this object, instead we are able to expose it to the user and allow for overridden implementations of this object's methods to be socketed into it, having the guarantee that for as long as these new functions are stored under keys storing the original functions (`emit`, `on` and `once`), the overrides will be called instead.

This allows for the user's to write some plumbing code, overriding the original emit to instead broadcast an event through multiple VM's internal execution contexts.