### PR TITLE
remove step and async/await code injection

### DIFF
--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -8,7 +8,7 @@ const Stepper = require('./stepper');
 
 const run = (code = '', options = {}) => {
     const {
-        stepTime = 15,
+        stepTime,
         on = {},
         context: userContext = {},
         es2015 = false,

--- a/src/stepper.js
+++ b/src/stepper.js
@@ -2,7 +2,7 @@ const EventEmitter = require('./event-emitter');
 
 class Stepper {
     constructor(options = {}) {
-        const { stepTime = 100 } = options;
+        const { stepTime = 1 } = options;
 
         this.events = EventEmitter();
         this.stepTime = stepTime;


### PR DESCRIPTION
Due to the high CPU demand of executing a step function per code expression we decided to remove this feature completely. It's now up to the programmer where to include a step and how much time it takes to resolve. The default step time will be the fastest possible (1ms). The step function continues to be injected in the global object so it can be used anywhere in your code.
We also removed the feature of automatically transforming every function call into an Async/await expression. It's now also up to the programmer to specify that in their code.